### PR TITLE
Use 'gt', 'gte','lt' and 'lte' iterator options

### DIFF
--- a/src/iterator.cc
+++ b/src/iterator.cc
@@ -36,6 +36,8 @@ Iterator::Iterator (
   , int          limit
   , bool         keyAsBuffer
   , bool         valueAsBuffer
+  , bool         startIsExclusive
+  , bool         endIsExclusive
 ) : database(database)
   , id(id)
   , start(start)
@@ -46,6 +48,8 @@ Iterator::Iterator (
   , limit(limit)
   , keyAsBuffer(keyAsBuffer)
   , valueAsBuffer(valueAsBuffer)
+  , startIsExclusive(startIsExclusive)
+  , endIsExclusive(endIsExclusive)
 {
   count     = 0;
   started   = false;
@@ -78,11 +82,21 @@ int Iterator::Next (MDB_val *key, MDB_val *value) {
       key->mv_data = (void*)start->data();
       key->mv_size = start->length();
       rc = mdb_cursor_get(cursor, key, value, MDB_SET_RANGE);
-      if (reverse) {
-        if (rc == MDB_NOTFOUND)
-          rc = mdb_cursor_get(cursor, key, value, MDB_LAST);
-        else if (rc == 0 && compare(start, key))
+      
+      if (rc == MDB_NOTFOUND) {
+        rc = mdb_cursor_get(cursor, key, value, reverse ? MDB_LAST : MDB_FIRST);
+      } else if (rc == 0) {
+        // when iterating in reverse:
+        //   - 'lt'  always backs up one key
+        //   - 'lte' backs up if the current key isn't equal to the start key
+        if (reverse && (startIsExclusive || compare(start, key) != 0)) {
           rc = mdb_cursor_get(cursor, key, value, MDB_PREV);
+        }
+        // when iterating forward:
+        //   - 'gt' advances one key if the current key is equal to the start key
+        else if (!reverse && startIsExclusive && compare(start, key) == 0) {
+          rc = mdb_cursor_get(cursor, key, value, MDB_NEXT);
+        }
       }
     } else if (reverse) {
       rc = mdb_cursor_get(cursor, key, value, MDB_LAST);
@@ -110,11 +124,10 @@ int Iterator::Next (MDB_val *key, MDB_val *value) {
   //if (end != NULL)
     //std::cerr << "***end=" << end->c_str() << ", " << reverse << ", " << compare(end, key) << std::endl;
 
-  // 'end' here is an inclusive test
   if ((limit < 0 || ++count <= limit)
       && (end == NULL
-          || (reverse && compare(end, key) <= 0)
-          || (!reverse && compare(end, key) >= 0))) {
+          || (reverse && compare(end, key) < (endIsExclusive ? 0 : 1))
+          || (!reverse && compare(end, key) > (endIsExclusive ? 0 : -1)))) {
     return 0; // good to continue
   }
 
@@ -261,15 +274,18 @@ NAN_METHOD(Iterator::New) {
 
   v8::Local<v8::Object> optionsObj;
 
+  bool startIsExclusive = false;
+  bool endIsExclusive = false;
+  
   if (args.Length() > 1 && args[2]->IsObject()) {
     optionsObj = v8::Local<v8::Object>::Cast(args[2]);
 
-    if (optionsObj->Has(NanSymbol("start"))
-        && (node::Buffer::HasInstance(optionsObj->Get(NanSymbol("start")))
-          || optionsObj->Get(NanSymbol("start"))->IsString())) {
+    if (optionsObj->Has(NanSymbol("gte"))
+        && (node::Buffer::HasInstance(optionsObj->Get(NanSymbol("gte")))
+          || optionsObj->Get(NanSymbol("gte"))->IsString())) {
 
       v8::Local<v8::Value> startBuffer =
-          v8::Local<v8::Value>::New(optionsObj->Get(NanSymbol("start")));
+          v8::Local<v8::Value>::New(optionsObj->Get(NanSymbol("gte")));
 
       // ignore start if it has size 0 since a Slice can't have length 0
       if (StringOrBufferLength(startBuffer) > 0) {
@@ -277,13 +293,32 @@ NAN_METHOD(Iterator::New) {
         start = new std::string((const char*)_start.mv_data, _start.mv_size);
       }
     }
+ 
+    if (optionsObj->Has(NanSymbol("gt"))
+        && (node::Buffer::HasInstance(optionsObj->Get(NanSymbol("gt")))
+          || optionsObj->Get(NanSymbol("gt"))->IsString())) {
 
-    if (optionsObj->Has(NanSymbol("end"))
-        && (node::Buffer::HasInstance(optionsObj->Get(NanSymbol("end")))
-          || optionsObj->Get(NanSymbol("end"))->IsString())) {
+      if (start != NULL) {
+        return NanThrowError("Only one of 'gt' or 'gte' is allowed");
+      }
+ 
+      v8::Local<v8::Value> startBuffer =
+          v8::Local<v8::Value>::New(optionsObj->Get(NanSymbol("gt")));
+
+      // ignore start if it has size 0 since a Slice can't have length 0
+      if (StringOrBufferLength(startBuffer) > 0) {
+        NL_STRING_OR_BUFFER_TO_MDVAL(_start, startBuffer, start)
+        start = new std::string((const char*)_start.mv_data, _start.mv_size);
+        startIsExclusive = true;
+      }
+    }
+    
+    if (optionsObj->Has(NanSymbol("lte"))
+        && (node::Buffer::HasInstance(optionsObj->Get(NanSymbol("lte")))
+          || optionsObj->Get(NanSymbol("lte"))->IsString())) {
 
       v8::Local<v8::Value> endBuffer =
-          v8::Local<v8::Value>::New(optionsObj->Get(NanSymbol("end")));
+          v8::Local<v8::Value>::New(optionsObj->Get(NanSymbol("lte")));
 
       // ignore end if it has size 0 since a Slice can't have length 0
       if (StringOrBufferLength(endBuffer) > 0) {
@@ -291,7 +326,26 @@ NAN_METHOD(Iterator::New) {
         end = new std::string((const char*)_end.mv_data, _end.mv_size);
       }
     }
+    
+    if (optionsObj->Has(NanSymbol("lt"))
+        && (node::Buffer::HasInstance(optionsObj->Get(NanSymbol("lt")))
+          || optionsObj->Get(NanSymbol("lt"))->IsString())) {
 
+      if (end != NULL) {
+        return NanThrowError("Only one of 'lt' or 'lte' is allowed");
+      }
+ 
+      v8::Local<v8::Value> endBuffer =
+          v8::Local<v8::Value>::New(optionsObj->Get(NanSymbol("lt")));
+
+      // ignore end if it has size 0 since a Slice can't have length 0
+      if (StringOrBufferLength(endBuffer) > 0) {
+        NL_STRING_OR_BUFFER_TO_MDVAL(_end, endBuffer, end)
+        end = new std::string((const char*)_end.mv_data, _end.mv_size);
+        endIsExclusive = true;
+      }
+    }
+ 
     if (!optionsObj.IsEmpty() && optionsObj->Has(NanSymbol("limit"))) {
       limit =
         v8::Local<v8::Integer>::Cast(optionsObj->Get(NanSymbol("limit")))->Value();
@@ -311,6 +365,15 @@ NAN_METHOD(Iterator::New) {
     , NanSymbol("valueAsBuffer")
     , false
   );
+  
+  if (reverse) {
+    std::string *tmpKey = start;
+    start = end;
+    end = tmpKey;
+    bool tmpExclusive = startIsExclusive;
+    startIsExclusive = endIsExclusive;
+    endIsExclusive = tmpExclusive;
+  }
 
   Iterator* iterator = new Iterator(
       database
@@ -323,6 +386,8 @@ NAN_METHOD(Iterator::New) {
     , limit
     , keyAsBuffer
     , valueAsBuffer
+    , startIsExclusive
+    , endIsExclusive
   );
   iterator->Wrap(args.This());
 

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -38,6 +38,8 @@ public:
     , int          limit
     , bool         keyAsBuffer
     , bool         valueAsBuffer
+    , bool         startIsExclusive
+    , bool         endIsExclusive
   );
 
   ~Iterator ();
@@ -62,6 +64,8 @@ private:
 public:
   bool         keyAsBuffer;
   bool         valueAsBuffer;
+  bool         startIsExclusive;
+  bool         endIsExclusive;
   bool         started;
   bool         nexting;
   bool         ended;


### PR DESCRIPTION
Previously only the legacy `"start"` and `"end"` options were supported, I've removed those though they could be added back as synonyms for "gte" and "lte" if necessary.

The logic for running the iterator has been reworked, and could most definitely use more test coverage.